### PR TITLE
chore(ci): run build and release on 20.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build_test_and_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Pin to the 2020 LTS to support a wider range of GLIBC versions